### PR TITLE
fix cross compilation on tuned compiler

### DIFF
--- a/meta-gir/recipes-gir/g-ir/g-ir-tools-host_1.42.0.bb
+++ b/meta-gir/recipes-gir/g-ir/g-ir-tools-host_1.42.0.bb
@@ -50,7 +50,7 @@ do_install_append () {
 # Because normal packages do not stage binaries into target root, we install
 # the binaries we need into the native root here with the .bin extension for
 # use by the qemu wrapper we provide around them
-MULTIMACH_TARGET_SYS = "${PACKAGE_ARCH}${HOST_VENDOR}-${HOST_OS}"
+MULTIMACH_TARGET_SYS = "${TARGET_SYS}"
 STAGING_BINDIR = "${STAGING_BINDIR_NATIVE}/${MULTIMACH_TARGET_SYS}"
 do_populate_sysroot[sstate-inputdirs] = "${SYSROOT_DESTDIR}/${STAGING_DIR_NATIVE}/"
 do_populate_sysroot[sstate-outputdirs] = "${STAGING_DIR_NATIVE}/"


### PR DESCRIPTION
when using a non default compiler (like when setting DEFAULTTUNE =
"cortexa7thf-neon-vfpv4" in a machine), then MULTIMACH_TARGET_SYS
is set to "cortexa7hf-vfp-vfpv4-neon", and the g-ir-tools-host
wrapper files are not copied in the path of cross-compiler in
the native sysroot (which stays
"build/tmp/sysroots/x86_64-linux/usr/bin/arm-poky-linux-gnueabi")

Using TARGET_SYS set to the correct path

Signed-off-by: Frederic Germain <frederic.germain@gmail.com>